### PR TITLE
[Feature] Booth methods

### DIFF
--- a/example/src/index.ts
+++ b/example/src/index.ts
@@ -53,7 +53,4 @@ process.on('SIGINT', () => {
   uw.disconnect();
 });
 
-uw.auth.login(credentials.email, credentials.password).then((user) => {
-  console.log(user);
-  uw.connect();
-});
+uw.auth.login(credentials.email, credentials.password).then(() => uw.connect());

--- a/example/src/index.ts
+++ b/example/src/index.ts
@@ -53,4 +53,7 @@ process.on('SIGINT', () => {
   uw.disconnect();
 });
 
-uw.auth.login(credentials.email, credentials.password).then(() => uw.connect());
+uw.auth.login(credentials.email, credentials.password).then((user) => {
+  console.log(user);
+  uw.connect();
+});

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -27,7 +27,7 @@ function getPathValue<I extends Record<string, any>, R>(
   return getPathValue(value, path);
 }
 
-function setPathValue(
+export function setPathValue(
   obj: { [key: string]: any },
   path: string[],
   value: any
@@ -41,5 +41,15 @@ function setPathValue(
 
   path.shift();
 
+  if (!obj[subPath]) {
+    obj[subPath] = {};
+  }
+
   return setPathValue(obj[subPath], path, value);
+}
+
+export function groupById<I extends { _id: string }>(
+  arr: I[]
+): Record<string, I> {
+  return arr.reduce((acc, item) => ({ ...acc, [item._id]: item }), {});
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,0 +1,45 @@
+export function parseDates<I>(obj: I, paths: string[]): I {
+  let newObj: I = JSON.parse(JSON.stringify(obj));
+
+  for (const path of paths) {
+    const subpaths = path.split('.');
+
+    setPathValue(
+      newObj,
+      [...subpaths],
+      new Date(getPathValue(obj, [...subpaths]))
+    );
+  }
+
+  return newObj;
+}
+
+function getPathValue<I extends Record<string, any>, R>(
+  obj: I,
+  path: string[]
+): R {
+  const value = obj[path[0]];
+  path.shift();
+
+  if (!path.length || typeof value === 'undefined' || value === null)
+    return value;
+
+  return getPathValue(value, path);
+}
+
+function setPathValue(
+  obj: { [key: string]: any },
+  path: string[],
+  value: any
+): { [key: string]: typeof value } {
+  const subPath = path[0];
+
+  if (path.length === 1 && subPath) {
+    obj[subPath] = value;
+    return obj;
+  }
+
+  path.shift();
+
+  return setPathValue(obj[subPath], path, value);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -227,7 +227,13 @@ export class uWave {
   // #endregion
 }
 
-const querystringify = (obj: object = {}) =>
+const querystringify = (obj: object = {}, keyPrefix?: string): string =>
   Object.entries(obj)
-    .map((pair) => pair.map(encodeURIComponent).join('='))
+    .map(([key, value]) =>
+      typeof value !== 'object'
+        ? [keyPrefix ? `${keyPrefix}[${key}]` : key, value]
+            .map(encodeURIComponent)
+            .join('=')
+        : querystringify(value, key)
+    )
     .join('&');

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,16 +3,16 @@ import { EventEmitter } from 'events';
 import fetch, { RequestInit } from 'node-fetch';
 
 import { Commands, SocketEvents, SocketPayloadsMap } from './types';
-import Auth from './modules/auth';
+import { Auth, Booth } from './modules';
 
 export interface IUWaveOptions {
+  apiBaseUrl: string;
+  wsConnectionString: string;
   authImmediately?: boolean;
   credentials?: {
     email: string;
     password: string;
   };
-  apiBaseUrl: string;
-  wsConnectionString: string;
 }
 
 export class uWave {
@@ -25,6 +25,7 @@ export class uWave {
   // #region modules
   private modules: {
     auth?: Auth;
+    booth?: Booth;
   } = {};
   // #endregion
 
@@ -56,6 +57,10 @@ export class uWave {
         this.socketToken = socketToken;
       }))
     );
+  }
+
+  get booth() {
+    return this.modules.booth || (this.modules.booth = new Booth(this));
   }
 
   public sendChat(message: string) {

--- a/src/modules/auth.ts
+++ b/src/modules/auth.ts
@@ -47,7 +47,7 @@ export default class Auth {
 
   public logout() {
     return this.uw
-      .delete<{}, uWaveAPI.LogoutResponse>('/auth')
+      .delete<{}, uWaveAPI.EmptyItemResponse>('/auth')
       .then(() => null);
   }
 }

--- a/src/modules/booth.ts
+++ b/src/modules/booth.ts
@@ -48,4 +48,10 @@ export default class Booth {
         return response;
       });
   }
+
+  public getVote(historyId: string) {
+    return this.uw
+      .get<{}, uWaveAPI.CurrentVoteResponse>(`/booth/${historyId}/vote`)
+      .then((res) => res.data);
+  }
 }

--- a/src/modules/booth.ts
+++ b/src/modules/booth.ts
@@ -3,10 +3,12 @@ import { uWave } from '..';
 import { parseDates } from '../helpers';
 import { uWaveAPI } from '../types';
 import Auth from './auth';
-import type { HistoryEntry, Media, User } from '../types/entities';
+import { HistoryEntry, Media, User, VOTE_DIRECTIONS } from '../types/entities';
 
 export default class Booth {
   private uw: uWave;
+
+  static VOTE_DIRECTIONS = VOTE_DIRECTIONS;
 
   constructor(uw: uWave) {
     this.uw = uw;
@@ -53,5 +55,17 @@ export default class Booth {
     return this.uw
       .get<{}, uWaveAPI.CurrentVoteResponse>(`/booth/${historyId}/vote`)
       .then((res) => res.data);
+  }
+
+  public vote(
+    historyId: string,
+    direction: VOTE_DIRECTIONS.UPVOTE | VOTE_DIRECTIONS.DOWNVOTE
+  ) {
+    return this.uw
+      .put<uWaveAPI.VoteBody, uWaveAPI.VoteResponse>(
+        `/booth/${historyId}/vote`,
+        { direction }
+      )
+      .then(() => null);
   }
 }

--- a/src/modules/booth.ts
+++ b/src/modules/booth.ts
@@ -69,10 +69,20 @@ export default class Booth {
       .then(() => null);
   }
 
-  public favorite(playlistId: string, historyId: string) {
-    return this.uw.put<uWaveAPI.FavoriteBody, uWaveAPI.FavoriteResponse>(
-      `/booth/favorite`,
-      { playlistId, historyId }
+  public favorite(playlistID: string, historyID: string) {
+    return this.uw.post<uWaveAPI.FavoriteBody, uWaveAPI.FavoriteResponse>(
+      '/booth/favorite',
+      { playlistID, historyID }
     );
+  }
+
+  public skip(userID: string, reason: string, remove: boolean) {
+    return this.uw
+      .post<uWaveAPI.SkipBody, uWaveAPI.SkipResponse>('/booth/skip', {
+        userID,
+        reason,
+        remove,
+      })
+      .then(() => null);
   }
 }

--- a/src/modules/booth.ts
+++ b/src/modules/booth.ts
@@ -3,7 +3,13 @@ import { uWave } from '..';
 import { parseDates } from '../helpers';
 import { uWaveAPI } from '../types';
 import Auth from './auth';
-import { HistoryEntry, Media, User, VOTE_DIRECTIONS } from '../types/entities';
+import {
+  HistoryEntry,
+  Media,
+  Playback,
+  User,
+  VOTE_DIRECTIONS,
+} from '../types/entities';
 
 export default class Booth {
   private uw: uWave;
@@ -70,10 +76,19 @@ export default class Booth {
   }
 
   public favorite(playlistID: string, historyID: string) {
-    return this.uw.post<uWaveAPI.FavoriteBody, uWaveAPI.FavoriteResponse>(
-      '/booth/favorite',
-      { playlistID, historyID }
-    );
+    return this.uw
+      .post<uWaveAPI.FavoriteBody, uWaveAPI.FavoriteResponse>(
+        '/booth/favorite',
+        { playlistID, historyID }
+      )
+      .then((response) => {
+        const playlistItem: Playback = {
+          ...response.data[0],
+          media: response.included.media[0],
+        };
+
+        return { item: playlistItem, playlistSize: response.meta.playlistSize };
+      });
   }
 
   public skip(remove?: boolean): Promise<null>;

--- a/src/modules/booth.ts
+++ b/src/modules/booth.ts
@@ -68,4 +68,11 @@ export default class Booth {
       )
       .then(() => null);
   }
+
+  public favorite(playlistId: string, historyId: string) {
+    return this.uw.put<uWaveAPI.FavoriteBody, uWaveAPI.FavoriteResponse>(
+      `/booth/favorite`,
+      { playlistId, historyId }
+    );
+  }
 }

--- a/src/modules/booth.ts
+++ b/src/modules/booth.ts
@@ -62,7 +62,7 @@ export default class Booth {
     direction: VOTE_DIRECTIONS.UPVOTE | VOTE_DIRECTIONS.DOWNVOTE
   ) {
     return this.uw
-      .put<uWaveAPI.VoteBody, uWaveAPI.VoteResponse>(
+      .put<uWaveAPI.VoteBody, uWaveAPI.EmptyItemResponse>(
         `/booth/${historyId}/vote`,
         { direction }
       )
@@ -76,13 +76,26 @@ export default class Booth {
     );
   }
 
-  public skip(userID: string, reason: string, remove: boolean) {
+  public skip(remove?: boolean): Promise<null>;
+  public skip(remove: boolean, userID: string, reason: string): Promise<null>;
+  public skip(remove?: boolean, userID?: string, reason?: string) {
     return this.uw
-      .post<uWaveAPI.SkipBody, uWaveAPI.SkipResponse>('/booth/skip', {
+      .post<uWaveAPI.SkipBody, uWaveAPI.EmptyItemResponse>('/booth/skip', {
         userID,
         reason,
         remove,
       })
+      .then(() => null);
+  }
+
+  public replaceBooth(userID: string) {
+    return this.uw
+      .post<uWaveAPI.ReplaceBoothBody, uWaveAPI.EmptyItemResponse>(
+        '/booth/skip',
+        {
+          userID,
+        }
+      )
       .then(() => null);
   }
 }

--- a/src/modules/booth.ts
+++ b/src/modules/booth.ts
@@ -15,6 +15,11 @@ export default class Booth {
   private uw: uWave;
 
   static VOTE_DIRECTIONS = VOTE_DIRECTIONS;
+  static HISTORY_ENTRY_DATE_FIELDS = [
+    'playedAt',
+    'media.media.createdAt',
+    'media.media.updatedAt',
+  ];
 
   constructor(uw: uWave) {
     this.uw = uw;
@@ -26,11 +31,10 @@ export default class Booth {
       .then((response) => {
         if (!response.data) return null;
 
-        return parseDates<HistoryEntry>(response.data, [
-          'playedAt',
-          'media.media.createdAt',
-          'media.media.updatedAt',
-        ]);
+        return parseDates<HistoryEntry>(
+          response.data,
+          Booth.HISTORY_ENTRY_DATE_FIELDS
+        );
       });
   }
 
@@ -56,9 +60,7 @@ export default class Booth {
             includedMedia[historyEntry.media.media];
 
           return parseDates<uWaveAPI.HistoryListEntry>(historyEntry, [
-            'playedAt',
-            'media.media.createdAt',
-            'media.media.updatedAt',
+            ...Booth.HISTORY_ENTRY_DATE_FIELDS,
             ...Auth.USER_DATE_FIELDS.map((field) => `user.${field}`),
           ]);
         });

--- a/src/modules/booth.ts
+++ b/src/modules/booth.ts
@@ -3,13 +3,8 @@ import { uWave } from '..';
 import { groupById, parseDates, setPathValue } from '../helpers';
 import { uWaveAPI } from '../types';
 import Auth from './auth';
-import {
-  HistoryEntry,
-  Media,
-  Playback,
-  User,
-  VOTE_DIRECTIONS,
-} from '../types/entities';
+import { HistoryEntry, Playback, VOTE_DIRECTIONS } from '../types/entities';
+import { PaginatedHistoryEntries } from '../types/domain';
 
 export default class Booth {
   private uw: uWave;
@@ -38,7 +33,11 @@ export default class Booth {
       });
   }
 
-  public getHistory(media?: string, offset?: number, limit?: number) {
+  public getHistory(
+    media?: string,
+    offset?: number,
+    limit?: number
+  ): Promise<PaginatedHistoryEntries> {
     const queryOptions: uWaveAPI.HistoryQuery = {};
 
     if (media) queryOptions.filter = { media };

--- a/src/modules/booth.ts
+++ b/src/modules/booth.ts
@@ -19,12 +19,6 @@ export default class Auth {
       .then((res) => res.data);
   }
 
-  public getSocketToken() {
-    return this.uw
-      .get<{}, uWaveAPI.SocketTokenResponse>('/auth/socket')
-      .then((res) => res.data.socketToken);
-  }
-
   public login(email: string, password: string) {
     return this.uw
       .post<uWaveAPI.LoginBody, uWaveAPI.LoginResponse>('/auth/login', {
@@ -42,5 +36,11 @@ export default class Auth {
     return this.uw
       .delete<{}, uWaveAPI.LogoutResponse>('/auth')
       .then(() => null);
+  }
+
+  public getSocketToken() {
+    return this.uw
+      .get<{}, uWaveAPI.SocketTokenResponse>('/auth/socket')
+      .then((res) => res.data.socketToken);
   }
 }

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -1,0 +1,2 @@
+export { default as Auth } from './auth';
+export { default as Booth } from './booth';

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,16 +1,37 @@
-import { Booth, User } from './entities';
+import { HistoryEntry, Media, Playback, User } from './entities';
 
-type ItemResponse<D = {}, M = {}> = {
-  meta: M;
+type ItemResponse<Data = {}, Meta = {}> = {
+  meta: Meta;
   links: { self?: string };
-  data: D;
+  data: Data;
+};
+
+type ListResponse<
+  DataList = {}[],
+  Included = {},
+  IncludedExtractionResults = {},
+  Meta = {}
+> = ItemResponse<DataList[], Meta & { included: Included }> & {
+  included: IncludedExtractionResults;
+};
+
+type PaginatedMeta = {
+  offset: number;
+  pageSize: number;
+  results: number;
+  total: number;
+};
+
+type PaginatedResponse<
+  Data = {},
+  Included = {},
+  IncludedExtractionResults = {}
+> = ListResponse<Data, Included, IncludedExtractionResults, PaginatedMeta> & {
+  links: { self: string; next: string; prev: string };
 };
 
 export declare namespace uWaveAPI {
-  type LoginBody = {
-    email: string;
-    password: string;
-  };
+  type LoginBody = { email: string; password: string };
 
   type LoginResponse = ItemResponse<
     User,
@@ -26,5 +47,21 @@ export declare namespace uWaveAPI {
 
   type CurrentUserResponse = ItemResponse<User | null>;
 
-  type BoothResponse = ItemResponse<Booth | null>;
+  type BoothResponse = ItemResponse<HistoryEntry | null>;
+
+  type HistoryQuery = { filter?: { media?: string } } & (
+    | { page?: number; limit?: number }
+    | { page: { offset?: number; limit?: number } }
+  );
+
+  type HistoryListEntry = HistoryEntry & {
+    media: Playback & { media: string };
+    user: string;
+  };
+
+  type HistoryResponse = PaginatedResponse<
+    HistoryListEntry,
+    { media: ['media.media']; user: ['user'] },
+    { media: Media[]; user: User[] }
+  >;
 }

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -55,10 +55,9 @@ export declare namespace uWaveAPI {
 
   type BoothResponse = ItemResponse<HistoryEntry | null>;
 
-  type HistoryQuery = { filter?: { media?: string } } & (
-    | { page?: number; limit?: number }
-    | { page: { offset?: number; limit?: number } }
-  );
+  type HistoryQuery = { filter?: { media?: string } } & {
+    page?: { offset?: number; limit?: number };
+  };
 
   type HistoryListEntry = HistoryEntry & {
     media: Playback & { media: string };

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,4 +1,10 @@
-import { HistoryEntry, Media, Playback, User } from './entities';
+import {
+  HistoryEntry,
+  Media,
+  Playback,
+  User,
+  VOTE_DIRECTIONS,
+} from './entities';
 
 type ItemResponse<Data = {}, Meta = {}> = {
   meta: Meta;
@@ -65,5 +71,11 @@ export declare namespace uWaveAPI {
     { media: Media[]; user: User[] }
   >;
 
-  type CurrentVoteResponse = ItemResponse<0 | 1 | -1>;
+  type CurrentVoteResponse = ItemResponse<VOTE_DIRECTIONS>;
+
+  type VoteBody = {
+    direction: VOTE_DIRECTIONS.UPVOTE | VOTE_DIRECTIONS.DOWNVOTE;
+  };
+
+  type VoteResponse = ItemResponse;
 }

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -79,7 +79,7 @@ export declare namespace uWaveAPI {
 
   type VoteResponse = ItemResponse;
 
-  type FavoriteBody = { playlistId: string; historyId: string };
+  type FavoriteBody = { playlistID: string; historyID: string };
 
   type FavoriteResponse = ListResponse<
     Playback & { media: string },
@@ -87,4 +87,10 @@ export declare namespace uWaveAPI {
     { media: Media[] },
     { playlistSize: number }
   >;
+
+  type SkipBody =
+    | { userID: string; reason: string; remove?: boolean }
+    | { remove?: boolean };
+
+  type SkipResponse = ItemResponse;
 }

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -21,7 +21,7 @@ type ListResponse<
   included: IncludedExtractionResults;
 };
 
-type PaginatedMeta = {
+export type PaginatedMeta = {
   offset: number;
   pageSize: number;
   results: number;

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,4 +1,4 @@
-import { User } from './entities';
+import { Booth, User } from './entities';
 
 type ItemResponse<D = {}, M = {}> = {
   meta: M;
@@ -25,4 +25,6 @@ export declare namespace uWaveAPI {
   type SocketTokenResponse = ItemResponse<{ socketToken: string }>;
 
   type CurrentUserResponse = ItemResponse<User | null>;
+
+  type BoothResponse = ItemResponse<Booth | null>;
 }

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -47,7 +47,7 @@ export declare namespace uWaveAPI {
     }
   >;
 
-  type LogoutResponse = ItemResponse;
+  type EmptyItemResponse = ItemResponse;
 
   type SocketTokenResponse = ItemResponse<{ socketToken: string }>;
 
@@ -77,8 +77,6 @@ export declare namespace uWaveAPI {
     direction: VOTE_DIRECTIONS.UPVOTE | VOTE_DIRECTIONS.DOWNVOTE;
   };
 
-  type VoteResponse = ItemResponse;
-
   type FavoriteBody = { playlistID: string; historyID: string };
 
   type FavoriteResponse = ListResponse<
@@ -92,5 +90,5 @@ export declare namespace uWaveAPI {
     | { userID: string; reason: string; remove?: boolean }
     | { remove?: boolean };
 
-  type SkipResponse = ItemResponse;
+  type ReplaceBoothBody = { userID: string };
 }

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -64,4 +64,6 @@ export declare namespace uWaveAPI {
     { media: ['media.media']; user: ['user'] },
     { media: Media[]; user: User[] }
   >;
+
+  type CurrentVoteResponse = ItemResponse<0 | 1 | -1>;
 }

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -78,4 +78,13 @@ export declare namespace uWaveAPI {
   };
 
   type VoteResponse = ItemResponse;
+
+  type FavoriteBody = { playlistId: string; historyId: string };
+
+  type FavoriteResponse = ListResponse<
+    Playback & { media: string },
+    { media: ['media'] },
+    { media: Media[] },
+    { playlistSize: number }
+  >;
 }

--- a/src/types/domain.ts
+++ b/src/types/domain.ts
@@ -1,0 +1,16 @@
+import { PaginatedMeta } from './api';
+import { HistoryEntry } from './entities';
+
+export type PaginatedHistoryEntries = PaginatedResponse<{
+  historyEntries: HistoryEntry[];
+}>;
+
+type PaginatedResponse<Items> = Items & {
+  pagination: Pagination<PaginatedResponse<Items>>;
+};
+
+type Pagination<Response> = PaginatedMeta & {
+  getPrevPage(): Promise<Response>;
+  getCurrentPage(): Promise<Response>;
+  getNextPage(): Promise<Response>;
+};

--- a/src/types/entities.ts
+++ b/src/types/entities.ts
@@ -40,7 +40,7 @@ export type User = {
 export type HistoryEntry = {
   historyID: string;
   playlistID: string;
-  userID: string;
+  user: User;
   playedAt: Date;
   media: Playback;
   stats: {

--- a/src/types/entities.ts
+++ b/src/types/entities.ts
@@ -37,7 +37,7 @@ export type User = {
   updatedAT: Date;
 };
 
-export type Booth = {
+export type HistoryEntry = {
   historyID: string;
   playlistID: string;
   userID: string;

--- a/src/types/entities.ts
+++ b/src/types/entities.ts
@@ -9,8 +9,8 @@ export type Media = {
   sourceType: 'youtube' | 'soundcloud';
   sourceID: number | string;
   sourceData: SourceData;
-  createdAt: string;
-  updatedAt: string;
+  createdAt: Date;
+  updatedAt: Date;
 };
 
 export type Playback = {
@@ -32,7 +32,20 @@ export type User = {
   language: string;
   exiled: boolean;
   activePlaylist?: string;
-  lastSeenAt: string;
-  createdAt: string;
-  updatedAT: string;
+  lastSeenAt: Date;
+  createdAt: Date;
+  updatedAT: Date;
+};
+
+export type Booth = {
+  historyID: string;
+  playlistID: string;
+  userID: string;
+  playedAt: Date;
+  media: Playback;
+  stats: {
+    upvotes: number;
+    downvotes: number;
+    favorites: number;
+  };
 };

--- a/src/types/entities.ts
+++ b/src/types/entities.ts
@@ -49,3 +49,9 @@ export type HistoryEntry = {
     favorites: number;
   };
 };
+
+export enum VOTE_DIRECTIONS {
+  UPVOTE = 1,
+  DIDNT_VOTE = 0,
+  DOWNVOTE = -1,
+}


### PR DESCRIPTION
This PR implements all the needed booth methods through a module exposed in the main class.

### Fixes
- Return objects for User type came with stringified [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) timestamps, they're now being parsed into [JavaScript Date objects](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date);

### New APIs
- A new Booth module is exposed through the `#booth` getter;
- `#booth.getBooth(): Promise<HistoryEntry | null>`: Tries to return the currently playing history entry;
- `#booth.getVote(historyId: string): Promise<VOTE_DIRECTION>`: Tries to return the current `VOTE_DIRECTION` enum;
- `#booth.getHistory(media?: string, offset?: number, limit?: number): Promise<PaginatedHistoryEntries>`:
  Tries to return the requested page of history entries in a `historyEntries` property. Also returns a `pagination` object containing page-related counters and pagination helpers for better DX;
- `#booth.vote(historyId: string, direction: VOTE_DIRECTION.UPVOTE | VOTE_DIRECTION.DOWNVOTE): Promise<null>`:
  Tries to perform a vote on the specified history entry if it is currently playing;
- `#booth.favorite(playlistId: string, historyId: string): Promise<{ item: PlaylistItem, playlistSize: number}>`:
  Tries to add the specified history entry to the specified playlist;
- `#booth.skip(remove?: boolean): Promise<null>`:
- `#booth.skip(remove: boolean, userId: string, reason: string): Promise<null>`:
  Tries to skip the currently playing media, performing a self skip if no user is specified and removing from booth if specified;
- `#booth.replaceBooth(userId: string): Promise<null>`:
  Tries to replace the currently playing user for the specified user;
