### PR TITLE
[Chore] Refactoring socket into it's own module

### DIFF
--- a/example/src/index.ts
+++ b/example/src/index.ts
@@ -17,29 +17,29 @@ const uw = new uWave({
 
 let isShuttingDown = false;
 
-uw.on('disconnected', () => {
+uw.socket.on('disconnected', () => {
   console.info('disconnected');
 
   if (isShuttingDown) return;
 
   // implement retry
 
-  uw.connect();
+  uw.socket.connect();
 });
 
-uw.on('error', (err) => {
+uw.socket.on('error', (err) => {
   console.error('error', err);
 });
 
-uw.on('login', () => {
+uw.socket.on('login', () => {
   console.info('logged in');
 });
 
-uw.on('connected', () => {
+uw.socket.on('connected', () => {
   console.info('connected');
 });
 
-uw.on('authenticated', () => {
+uw.socket.on('authenticated', () => {
   console.info('authenticated');
 
   uw.sendChat('hello world');
@@ -50,7 +50,9 @@ process.on('SIGINT', () => {
 
   isShuttingDown = true;
 
-  uw.disconnect();
+  uw.socket.disconnect();
 });
 
-uw.auth.login(credentials.email, credentials.password).then(() => uw.connect());
+uw.auth
+  .login(credentials.email, credentials.password)
+  .then(() => uw.socket.connect());

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,8 +12,8 @@ export interface IUWaveOptions {
   };
 }
 
-export type PrivateTokenRef = { token?: string };
-let privateTokenRef: PrivateTokenRef = {};
+export type PrivateSocketTokenRef = { token?: string };
+let privateSocketTokenRef: PrivateSocketTokenRef = {};
 
 export class uWave {
   private jwt?: string;
@@ -49,7 +49,7 @@ export class uWave {
       this.modules.auth ||
       (this.modules.auth = new Auth(this, (jwt, socketToken) => {
         this.jwt = jwt;
-        privateTokenRef.token = socketToken;
+        privateSocketTokenRef.token = socketToken;
       }))
     );
   }
@@ -57,7 +57,7 @@ export class uWave {
   get socket() {
     return (
       this.modules.socket ||
-      (this.modules.socket = new Socket(this, privateTokenRef))
+      (this.modules.socket = new Socket(this, privateSocketTokenRef))
     );
   }
 

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -1,2 +1,5 @@
 export { default as Auth } from './auth';
 export { default as Booth } from './booth';
+
+// internal
+export { default as Socket } from './socket';

--- a/src/modules/socket.ts
+++ b/src/modules/socket.ts
@@ -1,10 +1,10 @@
 import * as WebSocket from 'ws';
 import { EventEmitter } from 'events';
 
-import { PrivateTokenRef, uWave } from '..';
+import { PrivateSocketTokenRef, uWave } from '..';
 import { Commands, SocketEvents, SocketPayloadsMap } from '../types';
 
-let privateTokenRef: PrivateTokenRef = {};
+let privateSocketTokenRef: PrivateSocketTokenRef = {};
 
 export default class Socket {
   private uw: uWave;
@@ -14,11 +14,11 @@ export default class Socket {
 
   static KEEP_ALIVE_MESSAGE = '-';
 
-  constructor(uw: uWave, tokenRef: PrivateTokenRef) {
+  constructor(uw: uWave, tokenRef: PrivateSocketTokenRef) {
     this.uw = uw;
     this.emitter = new EventEmitter();
 
-    privateTokenRef.token = tokenRef.token;
+    privateSocketTokenRef.token = tokenRef.token;
   }
 
   public get isConnected() {
@@ -80,15 +80,15 @@ export default class Socket {
 
     if (!this.socket || !this.isConnected) return;
 
-    if (!privateTokenRef.token && this.uw.isAuthenticated) {
-      privateTokenRef.token = await this.uw.auth.getSocketToken();
+    if (!privateSocketTokenRef.token && this.uw.isAuthenticated) {
+      privateSocketTokenRef.token = await this.uw.auth.getSocketToken();
     }
 
-    if (privateTokenRef.token) {
-      this.socket.send(privateTokenRef.token);
+    if (privateSocketTokenRef.token) {
+      this.socket.send(privateSocketTokenRef.token);
 
       // the token is expired after being validated
-      delete privateTokenRef.token;
+      delete privateSocketTokenRef.token;
     }
   }
 

--- a/src/modules/socket.ts
+++ b/src/modules/socket.ts
@@ -21,7 +21,6 @@ export default class Socket {
     privateTokenRef.token = tokenRef.token;
   }
 
-  // #region socket
   public get isConnected() {
     return this.socket?.readyState === WebSocket.OPEN;
   }
@@ -124,5 +123,4 @@ export default class Socket {
         break;
     }
   }
-  // #endregion
 }

--- a/src/modules/socket.ts
+++ b/src/modules/socket.ts
@@ -1,0 +1,128 @@
+import * as WebSocket from 'ws';
+import { EventEmitter } from 'events';
+
+import { PrivateTokenRef, uWave } from '..';
+import { Commands, SocketEvents, SocketPayloadsMap } from '../types';
+
+let privateTokenRef: PrivateTokenRef = {};
+
+export default class Socket {
+  private uw: uWave;
+
+  private socket?: WebSocket;
+  private emitter: EventEmitter;
+
+  static KEEP_ALIVE_MESSAGE = '-';
+
+  constructor(uw: uWave, tokenRef: PrivateTokenRef) {
+    this.uw = uw;
+    this.emitter = new EventEmitter();
+
+    privateTokenRef.token = tokenRef.token;
+  }
+
+  // #region socket
+  public get isConnected() {
+    return this.socket?.readyState === WebSocket.OPEN;
+  }
+
+  public once<E extends Commands>(
+    eventName: E,
+    listener: (payload: SocketPayloadsMap[E]) => void
+  ) {
+    return this.emitter.on(eventName, listener);
+  }
+
+  public on<E extends Commands>(
+    eventName: E,
+    listener: (payload: SocketPayloadsMap[E]) => void
+  ) {
+    return this.emitter.on(eventName, listener);
+  }
+
+  public off<E extends Commands>(
+    eventName: E,
+    listener: (payload: SocketPayloadsMap[E]) => void
+  ) {
+    return this.emitter.off(eventName, listener);
+  }
+
+  public connect() {
+    return this.connectSocket(this.uw.options.wsConnectionString);
+  }
+
+  public disconnect() {
+    if (this.socket) {
+      this.socket.close();
+    }
+  }
+
+  public emit<E extends Commands>(command: E, payload?: SocketPayloadsMap[E]) {
+    return this.emitter.emit(command, payload);
+  }
+
+  public send<I>(message: I) {
+    if (!this.socket || this.socket.readyState !== WebSocket.OPEN) return;
+
+    return this.socket.send(JSON.stringify(message));
+  }
+
+  private connectSocket(connectionString: string) {
+    this.socket = new WebSocket(connectionString);
+
+    this.socket.onopen = this.onSocketOpen.bind(this);
+    this.socket.onclose = this.onSocketClose.bind(this);
+    this.socket.onerror = this.onSocketError.bind(this);
+    this.socket.onmessage = this.onSocketMessage.bind(this);
+  }
+
+  private async onSocketOpen(/* event: WebSocket.OpenEvent */) {
+    this.emit('connected');
+
+    if (!this.socket || !this.isConnected) return;
+
+    if (!privateTokenRef.token && this.uw.isAuthenticated) {
+      privateTokenRef.token = await this.uw.auth.getSocketToken();
+    }
+
+    if (privateTokenRef.token) {
+      this.socket.send(privateTokenRef.token);
+
+      // the token is expired after being validated
+      delete privateTokenRef.token;
+    }
+  }
+
+  private onSocketClose(event: WebSocket.CloseEvent) {
+    event.target.removeAllListeners();
+    event.target.terminate();
+    delete this.socket;
+
+    this.emit('disconnected');
+  }
+
+  private onSocketError(/* event: WebSocket.ErrorEvent */) {
+    this.emit('error');
+  }
+
+  private onSocketMessage(event: WebSocket.MessageEvent) {
+    if (event.data === Socket.KEEP_ALIVE_MESSAGE) return;
+    if (typeof event.data !== 'string') return;
+
+    let payload: SocketEvents;
+
+    try {
+      payload = JSON.parse(event.data);
+    } catch (err) {
+      console.error(err);
+      return;
+    }
+
+    switch (payload.command) {
+      default:
+        this.emit(payload.command, payload.data);
+        break;
+    }
+  }
+  // #endregion
+}


### PR DESCRIPTION
This PR refactors socket-related behavior into it's own module.

All previously socket related methods are now available through the `socket` getter, such as:
- `#isConnected`;
- `#once`;
- `#on`;
- `#off`;
- `#connect`;
- `#disconnect`;
- `#emit`;
- `#send`.
