### PR TITLE
[Chore] Refactoring http into it's own module

### DIFF
--- a/.github/workflows/release.continuous-deployment.yml
+++ b/.github/workflows/release.continuous-deployment.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - beta
 jobs:
   release:
     name: Release

--- a/.releaserc
+++ b/.releaserc
@@ -1,5 +1,5 @@
 {
-  "branches": ["main"],
+  "branches": ["main", { name: "beta", prerelease: true }],
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",

--- a/example/src/index.ts
+++ b/example/src/index.ts
@@ -9,10 +9,8 @@ const credentials = {
 };
 
 const uw = new uWave({
-  authImmediately: false,
   apiBaseUrl: process.env.API_BASE_URL || '',
   wsConnectionString: process.env.WEBSOCKET_CONNECTION_STRING || '',
-  // credentials,
 });
 
 let isShuttingDown = false;

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,6 @@
         "eslint-plugin-jest": "24.3.6",
         "husky": "7.0.0",
         "jest": "27.0.4",
-        "lint-staged": "11.0.0",
         "prettier": "2.2.1",
         "ts-jest": "27.0.3",
         "typescript": "4.1.5"
@@ -2655,18 +2654,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/cli-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-      "dev": true,
-      "dependencies": {
-        "restore-cursor": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/cli-table": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.6.tgz",
@@ -2678,22 +2665,6 @@
       },
       "engines": {
         "node": ">= 0.2.0"
-      }
-    },
-    "node_modules/cli-truncate": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
-      "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
-      "dev": true,
-      "dependencies": {
-        "slice-ansi": "^3.0.0",
-        "string-width": "^4.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cliui": {
@@ -2767,15 +2738,6 @@
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/commander": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 10"
       }
     },
     "node_modules/commitizen": {
@@ -5056,12 +5018,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/get-own-enumerable-property-symbols": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
-      "integrity": "sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==",
-      "dev": true
-    },
     "node_modules/get-package-type": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
@@ -5748,15 +5704,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-regexp": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
-      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/is-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
@@ -5811,18 +5758,6 @@
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
-    },
-    "node_modules/is-unicode-supported": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
-      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/is-utf8": {
       "version": "0.2.1",
@@ -6843,56 +6778,6 @@
       "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
       "dev": true
     },
-    "node_modules/lint-staged": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-11.0.0.tgz",
-      "integrity": "sha512-3rsRIoyaE8IphSUtO1RVTFl1e0SLBtxxUOPBtHxQgBHS5/i6nqvjcUfNioMa4BU9yGnPzbO+xkfLtXtxBpCzjw==",
-      "dev": true,
-      "dependencies": {
-        "chalk": "^4.1.1",
-        "cli-truncate": "^2.1.0",
-        "commander": "^7.2.0",
-        "cosmiconfig": "^7.0.0",
-        "debug": "^4.3.1",
-        "dedent": "^0.7.0",
-        "enquirer": "^2.3.6",
-        "execa": "^5.0.0",
-        "listr2": "^3.8.2",
-        "log-symbols": "^4.1.0",
-        "micromatch": "^4.0.4",
-        "normalize-path": "^3.0.0",
-        "please-upgrade-node": "^3.2.0",
-        "string-argv": "0.3.1",
-        "stringify-object": "^3.3.0"
-      },
-      "bin": {
-        "lint-staged": "bin/lint-staged.js"
-      },
-      "funding": {
-        "url": "https://opencollective.com/lint-staged"
-      }
-    },
-    "node_modules/listr2": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/listr2/-/listr2-3.10.0.tgz",
-      "integrity": "sha512-eP40ZHihu70sSmqFNbNy2NL1YwImmlMmPh9WO5sLmPDleurMHt3n+SwEWNu2kzKScexZnkyFtc1VI0z/TGlmpw==",
-      "dev": true,
-      "dependencies": {
-        "cli-truncate": "^2.1.0",
-        "colorette": "^1.2.2",
-        "log-update": "^4.0.0",
-        "p-map": "^4.0.0",
-        "rxjs": "^6.6.7",
-        "through": "^2.3.8",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "enquirer": ">= 2.3.0 < 3"
-      }
-    },
     "node_modules/load-json-file": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
@@ -7020,71 +6905,6 @@
       "integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=",
       "dev": true,
       "peer": true
-    },
-    "node_modules/log-symbols": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
-      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
-      "dev": true,
-      "dependencies": {
-        "chalk": "^4.1.0",
-        "is-unicode-supported": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/log-update": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/log-update/-/log-update-4.0.0.tgz",
-      "integrity": "sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==",
-      "dev": true,
-      "dependencies": {
-        "ansi-escapes": "^4.3.0",
-        "cli-cursor": "^3.1.0",
-        "slice-ansi": "^4.0.0",
-        "wrap-ansi": "^6.2.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/log-update/node_modules/slice-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
-      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "astral-regex": "^2.0.0",
-        "is-fullwidth-code-point": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
-      }
-    },
-    "node_modules/log-update/node_modules/wrap-ansi": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/longest": {
       "version": "2.0.1",
@@ -10559,6 +10379,7 @@
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
       "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "aggregate-error": "^3.0.0"
       },
@@ -10876,15 +10697,6 @@
       "dev": true,
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/please-upgrade-node": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
-      "integrity": "sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==",
-      "dev": true,
-      "dependencies": {
-        "semver-compare": "^1.0.0"
       }
     },
     "node_modules/prelude-ls": {
@@ -11324,19 +11136,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/restore-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-      "dev": true,
-      "dependencies": {
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/retry": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
@@ -11503,12 +11302,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/semver-compare": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
-      "dev": true
     },
     "node_modules/semver-diff": {
       "version": "3.1.1",
@@ -11709,20 +11502,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/slice-ansi": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
-      "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "astral-regex": "^2.0.0",
-        "is-fullwidth-code-point": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -11867,15 +11646,6 @@
         "safe-buffer": "~5.1.0"
       }
     },
-    "node_modules/string-argv": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.1.tgz",
-      "integrity": "sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.6.19"
-      }
-    },
     "node_modules/string-length": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
@@ -11947,29 +11717,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/stringify-object": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
-      "integrity": "sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==",
-      "dev": true,
-      "dependencies": {
-        "get-own-enumerable-property-symbols": "^3.0.0",
-        "is-obj": "^1.0.1",
-        "is-regexp": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/stringify-object/node_modules/is-obj": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/strip-ansi": {
@@ -14875,15 +14622,6 @@
       "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
       "dev": true
     },
-    "cli-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-      "dev": true,
-      "requires": {
-        "restore-cursor": "^3.1.0"
-      }
-    },
     "cli-table": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.6.tgz",
@@ -14892,16 +14630,6 @@
       "peer": true,
       "requires": {
         "colors": "1.0.3"
-      }
-    },
-    "cli-truncate": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
-      "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
-      "dev": true,
-      "requires": {
-        "slice-ansi": "^3.0.0",
-        "string-width": "^4.2.0"
       }
     },
     "cliui": {
@@ -14963,12 +14691,6 @@
       "requires": {
         "delayed-stream": "~1.0.0"
       }
-    },
-    "commander": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
-      "dev": true
     },
     "commitizen": {
       "version": "4.2.4",
@@ -16745,12 +16467,6 @@
         "has-symbols": "^1.0.1"
       }
     },
-    "get-own-enumerable-property-symbols": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
-      "integrity": "sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==",
-      "dev": true
-    },
     "get-package-type": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
@@ -17257,12 +16973,6 @@
         "has-symbols": "^1.0.2"
       }
     },
-    "is-regexp": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
-      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
-      "dev": true
-    },
     "is-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
@@ -17298,12 +17008,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-      "dev": true
-    },
-    "is-unicode-supported": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
-      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
       "dev": true
     },
     "is-utf8": {
@@ -18114,44 +17818,6 @@
       "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
       "dev": true
     },
-    "lint-staged": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-11.0.0.tgz",
-      "integrity": "sha512-3rsRIoyaE8IphSUtO1RVTFl1e0SLBtxxUOPBtHxQgBHS5/i6nqvjcUfNioMa4BU9yGnPzbO+xkfLtXtxBpCzjw==",
-      "dev": true,
-      "requires": {
-        "chalk": "^4.1.1",
-        "cli-truncate": "^2.1.0",
-        "commander": "^7.2.0",
-        "cosmiconfig": "^7.0.0",
-        "debug": "^4.3.1",
-        "dedent": "^0.7.0",
-        "enquirer": "^2.3.6",
-        "execa": "^5.0.0",
-        "listr2": "^3.8.2",
-        "log-symbols": "^4.1.0",
-        "micromatch": "^4.0.4",
-        "normalize-path": "^3.0.0",
-        "please-upgrade-node": "^3.2.0",
-        "string-argv": "0.3.1",
-        "stringify-object": "^3.3.0"
-      }
-    },
-    "listr2": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/listr2/-/listr2-3.10.0.tgz",
-      "integrity": "sha512-eP40ZHihu70sSmqFNbNy2NL1YwImmlMmPh9WO5sLmPDleurMHt3n+SwEWNu2kzKScexZnkyFtc1VI0z/TGlmpw==",
-      "dev": true,
-      "requires": {
-        "cli-truncate": "^2.1.0",
-        "colorette": "^1.2.2",
-        "log-update": "^4.0.0",
-        "p-map": "^4.0.0",
-        "rxjs": "^6.6.7",
-        "through": "^2.3.8",
-        "wrap-ansi": "^7.0.0"
-      }
-    },
     "load-json-file": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
@@ -18269,52 +17935,6 @@
       "integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=",
       "dev": true,
       "peer": true
-    },
-    "log-symbols": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
-      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
-      "dev": true,
-      "requires": {
-        "chalk": "^4.1.0",
-        "is-unicode-supported": "^0.1.0"
-      }
-    },
-    "log-update": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/log-update/-/log-update-4.0.0.tgz",
-      "integrity": "sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==",
-      "dev": true,
-      "requires": {
-        "ansi-escapes": "^4.3.0",
-        "cli-cursor": "^3.1.0",
-        "slice-ansi": "^4.0.0",
-        "wrap-ansi": "^6.2.0"
-      },
-      "dependencies": {
-        "slice-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
-          "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.0.0",
-            "astral-regex": "^2.0.0",
-            "is-fullwidth-code-point": "^3.0.0"
-          }
-        },
-        "wrap-ansi": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.0.0",
-            "string-width": "^4.1.0",
-            "strip-ansi": "^6.0.0"
-          }
-        }
-      }
     },
     "longest": {
       "version": "2.0.1",
@@ -20854,6 +20474,7 @@
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
       "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "aggregate-error": "^3.0.0"
       }
@@ -21091,15 +20712,6 @@
           "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
           "dev": true
         }
-      }
-    },
-    "please-upgrade-node": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
-      "integrity": "sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==",
-      "dev": true,
-      "requires": {
-        "semver-compare": "^1.0.0"
       }
     },
     "prelude-ls": {
@@ -21457,16 +21069,6 @@
         }
       }
     },
-    "restore-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-      "dev": true,
-      "requires": {
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2"
-      }
-    },
     "retry": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
@@ -21598,12 +21200,6 @@
       "requires": {
         "lru-cache": "^6.0.0"
       }
-    },
-    "semver-compare": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
-      "dev": true
     },
     "semver-diff": {
       "version": "3.1.1",
@@ -21763,17 +21359,6 @@
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true
     },
-    "slice-ansi": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
-      "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
-      "dev": true,
-      "requires": {
-        "ansi-styles": "^4.0.0",
-        "astral-regex": "^2.0.0",
-        "is-fullwidth-code-point": "^3.0.0"
-      }
-    },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -21907,12 +21492,6 @@
         "safe-buffer": "~5.1.0"
       }
     },
-    "string-argv": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.1.tgz",
-      "integrity": "sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==",
-      "dev": true
-    },
     "string-length": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
@@ -21969,25 +21548,6 @@
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
-      }
-    },
-    "stringify-object": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
-      "integrity": "sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==",
-      "dev": true,
-      "requires": {
-        "get-own-enumerable-property-symbols": "^3.0.0",
-        "is-obj": "^1.0.1",
-        "is-regexp": "^1.0.0"
-      },
-      "dependencies": {
-        "is-obj": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-          "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
-          "dev": true
-        }
       }
     },
     "strip-ansi": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "eslint-plugin-jest": "24.3.6",
     "husky": "7.0.0",
     "jest": "27.0.4",
-    "lint-staged": "11.0.0",
     "prettier": "2.2.1",
     "ts-jest": "27.0.3",
     "typescript": "4.1.5"

--- a/package.json
+++ b/package.json
@@ -61,8 +61,6 @@
       "npm run format:ts -- --write",
       "npm run lint:ts -- --fix",
       "npm run test:ts -- --bail --findRelatedTests"
-    ],
-    "*.js": "eslint --cache --fix",
-    "*.format:all": "prettier --write"
+    ]
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ export interface IUWaveOptions {
 
 export type PrivateTokenRef = { token?: string };
 let privateSocketTokenRef: PrivateTokenRef = {};
-const privateHttpTokenRef: PrivateTokenRef = {};
+let privateHttpTokenRef: PrivateTokenRef = {};
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export class uWave {
@@ -53,7 +53,7 @@ export class uWave {
   get auth(): Auth {
     if (!this.modules.auth) {
       this.modules.auth = new Auth(this, (jwt, socketToken) => {
-        this.jwt = jwt;
+        privateHttpTokenRef = { token: jwt };
         privateSocketTokenRef = { token: socketToken };
       });
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,3 @@
-import fetch, { RequestInit } from 'node-fetch';
-
 import { Auth, Booth, Http, Socket } from './modules';
 
 export interface IUWaveOptions {
@@ -18,7 +16,6 @@ let privateHttpTokenRef: PrivateTokenRef = {};
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export class uWave {
-  private jwt?: string;
   public options: IUWaveOptions;
 
   // #region modules
@@ -92,69 +89,4 @@ export class uWave {
   public vote(direction: 1 | -1): void {
     return this.socket.send({ command: 'vote', data: direction });
   }
-
-  // #region http
-  public request<I extends {}, R extends {}>(
-    method: 'get' | 'post' | 'put' | 'patch' | 'delete',
-    endpoint: string,
-    data?: I
-  ): Promise<R> {
-    const fetchOptions: RequestInit = { method };
-    fetchOptions.headers = {};
-
-    if (this.jwt) {
-      fetchOptions.headers.Authorization = `JWT ${this.jwt}`;
-    }
-
-    if (!process.env.UWAVE_API_BASE_URL) {
-      throw new Error('Env "UWAVE_API_BASE_URL" is not set.');
-    }
-
-    let url = process.env.UWAVE_API_BASE_URL + endpoint;
-
-    if (method === 'get' && data) {
-      const querystring = querystringify(data);
-
-      if (querystring) {
-        url += `?${querystring}`;
-      }
-    } else if (data) {
-      fetchOptions.headers['Content-Type'] = 'application/json';
-      fetchOptions.body = JSON.stringify(data);
-    }
-
-    return fetch(url, fetchOptions).then((res) => res.json() as Promise<R>);
-  }
-
-  public get<I, R>(endpoint: string, query?: I): Promise<R> {
-    return this.request<I, R>('get', endpoint, query);
-  }
-
-  public post<I, R>(endpoint: string, data?: I): Promise<R> {
-    return this.request<I, R>('post', endpoint, data);
-  }
-
-  public put<I, R>(endpoint: string, data?: I): Promise<R> {
-    return this.request<I, R>('put', endpoint, data);
-  }
-
-  public patch<I, R>(endpoint: string, data?: I): Promise<R> {
-    return this.request<I, R>('patch', endpoint, data);
-  }
-
-  public delete<I, R>(endpoint: string, query?: I): Promise<R> {
-    return this.request<I, R>('delete', endpoint, query);
-  }
-  // #endregion
 }
-
-const querystringify = (obj: object = {}, keyPrefix?: string): string =>
-  Object.entries(obj)
-    .map(([key, value]) =>
-      typeof value !== 'object'
-        ? [keyPrefix ? `${keyPrefix}[${key}]` : key, value]
-            .map(encodeURIComponent)
-            .join('=')
-        : querystringify(value, key)
-    )
-    .join('&');

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,8 +12,8 @@ export interface IUWaveOptions {
   };
 }
 
-export type PrivateSocketTokenRef = { token?: string };
-const privateSocketTokenRef: PrivateSocketTokenRef = {};
+export type PrivateTokenRef = { token?: string };
+let privateSocketTokenRef: PrivateTokenRef = {};
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export class uWave {
@@ -52,7 +52,7 @@ export class uWave {
     if (!this.modules.auth) {
       this.modules.auth = new Auth(this, (jwt, socketToken) => {
         this.jwt = jwt;
-        privateSocketTokenRef.token = socketToken;
+        privateSocketTokenRef = { token: socketToken };
       });
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,10 +85,6 @@ export class uWave {
     return this.modules.booth;
   }
 
-  get isAuthenticated(): boolean {
-    return !!this.jwt;
-  }
-
   public sendChat(message: string): void {
     return this.socket.send({ command: 'sendChat', data: message });
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,11 +3,6 @@ import { Auth, Booth, Http, Socket } from './modules';
 export interface IUWaveOptions {
   apiBaseUrl: string;
   wsConnectionString: string;
-  authImmediately?: boolean;
-  credentials?: {
-    email: string;
-    password: string;
-  };
 }
 
 export type PrivateTokenRef = { token?: string };
@@ -29,22 +24,6 @@ export class uWave {
 
   constructor(options: IUWaveOptions) {
     this.options = options;
-
-    if (!process.env.UWAVE_API_BASE_URL) {
-      process.env.UWAVE_API_BASE_URL = options.apiBaseUrl;
-    }
-
-    const { credentials } = options;
-    if (options.authImmediately && credentials) {
-      delete this.options.credentials;
-
-      this.auth
-        .login(credentials.email, credentials.password)
-        .then(() => this.socket.connect())
-        .catch((err) => {
-          throw err;
-        });
-    }
   }
 
   get auth(): Auth {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import fetch, { RequestInit } from 'node-fetch';
 
-import { Auth, Booth, Socket } from './modules';
+import { Auth, Booth, Http, Socket } from './modules';
 
 export interface IUWaveOptions {
   apiBaseUrl: string;
@@ -14,6 +14,7 @@ export interface IUWaveOptions {
 
 export type PrivateTokenRef = { token?: string };
 let privateSocketTokenRef: PrivateTokenRef = {};
+const privateHttpTokenRef: PrivateTokenRef = {};
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export class uWave {
@@ -25,6 +26,7 @@ export class uWave {
     auth?: Auth;
     booth?: Booth;
     socket?: Socket;
+    http?: Http;
   } = {};
   // #endregion
 
@@ -65,6 +67,14 @@ export class uWave {
     }
 
     return this.modules.socket;
+  }
+
+  get http(): Http {
+    if (!this.modules.http) {
+      this.modules.http = new Http(this, privateHttpTokenRef);
+    }
+
+    return this.modules.http;
   }
 
   get booth(): Booth {

--- a/src/modules/auth.ts
+++ b/src/modules/auth.ts
@@ -18,7 +18,7 @@ export default class Auth {
   }
 
   public getCurrentUser(): Promise<User | null> {
-    return this.uw
+    return this.uw.http
       .get<{}, uWaveAPI.CurrentUserResponse>('/auth')
       .then((response) => {
         if (!response.data) return null;
@@ -28,13 +28,13 @@ export default class Auth {
   }
 
   public getSocketToken(): Promise<string> {
-    return this.uw
+    return this.uw.http
       .get<{}, uWaveAPI.SocketTokenResponse>('/auth/socket')
       .then((res) => res.data.socketToken);
   }
 
   public login(email: string, password: string): Promise<User> {
-    return this.uw
+    return this.uw.http
       .post<uWaveAPI.LoginBody, uWaveAPI.LoginResponse>('/auth/login', {
         email,
         password,
@@ -47,7 +47,7 @@ export default class Auth {
   }
 
   public logout(): Promise<null> {
-    return this.uw
+    return this.uw.http
       .delete<{}, uWaveAPI.EmptyItemResponse>('/auth')
       .then(() => null);
   }

--- a/src/modules/booth.ts
+++ b/src/modules/booth.ts
@@ -21,7 +21,7 @@ export default class Booth {
   }
 
   public getBooth(): Promise<HistoryEntry | null> {
-    return this.uw
+    return this.uw.http
       .get<{}, uWaveAPI.BoothResponse>('/booth')
       .then((response) => {
         if (!response.data) return null;
@@ -43,7 +43,7 @@ export default class Booth {
     if (media) queryOptions.filter = { media };
     if (offset || limit) queryOptions.page = { offset, limit };
 
-    return this.uw
+    return this.uw.http
       .get<uWaveAPI.HistoryQuery, uWaveAPI.HistoryResponse>(
         '/booth/history',
         queryOptions
@@ -99,7 +99,7 @@ export default class Booth {
   }
 
   public getVote(historyId: string): Promise<VoteDirections> {
-    return this.uw
+    return this.uw.http
       .get<{}, uWaveAPI.CurrentVoteResponse>(`/booth/${historyId}/vote`)
       .then((res) => res.data);
   }
@@ -108,7 +108,7 @@ export default class Booth {
     historyId: string,
     direction: VoteDirections.UPVOTE | VoteDirections.DOWNVOTE
   ): Promise<null> {
-    return this.uw
+    return this.uw.http
       .put<uWaveAPI.VoteBody, uWaveAPI.EmptyItemResponse>(
         `/booth/${historyId}/vote`,
         { direction }
@@ -120,7 +120,7 @@ export default class Booth {
     playlistID: string,
     historyID: string
   ): Promise<{ item: Playback; playlistSize: number }> {
-    return this.uw
+    return this.uw.http
       .post<uWaveAPI.FavoriteBody, uWaveAPI.FavoriteResponse>(
         '/booth/favorite',
         { playlistID, historyID }
@@ -142,7 +142,7 @@ export default class Booth {
     userID?: string,
     reason?: string
   ): Promise<null> {
-    return this.uw
+    return this.uw.http
       .post<uWaveAPI.SkipBody, uWaveAPI.EmptyItemResponse>('/booth/skip', {
         userID,
         reason,
@@ -152,7 +152,7 @@ export default class Booth {
   }
 
   public replaceBooth(userID: string): Promise<null> {
-    return this.uw
+    return this.uw.http
       .post<uWaveAPI.ReplaceBoothBody, uWaveAPI.EmptyItemResponse>(
         '/booth/skip',
         {

--- a/src/modules/http.spec.ts
+++ b/src/modules/http.spec.ts
@@ -1,0 +1,16 @@
+import { PrivateTokenRef, uWave } from '..';
+import HttpModule from './http';
+
+test('should create an socket module instance', () => {
+  const uw = new (class Test {})() as uWave;
+  const privateHttpTokenRef: PrivateTokenRef = {};
+  const http = new HttpModule(uw, privateHttpTokenRef);
+
+  expect(http).toBeInstanceOf(HttpModule);
+  expect(http['uw']).toEqual(uw);
+  expect(http).toMatchInlineSnapshot(`
+HttpModule {
+  "uw": Test {},
+}
+`);
+});

--- a/src/modules/http.ts
+++ b/src/modules/http.ts
@@ -1,0 +1,82 @@
+import fetch, { RequestInit } from 'node-fetch';
+
+import { PrivateTokenRef, uWave } from '..';
+
+let privateHttpTokenRef: PrivateTokenRef = {};
+
+export default class HttpModule {
+  private uw: uWave;
+
+  constructor(uw: uWave, tokenRef: PrivateTokenRef) {
+    this.uw = uw;
+
+    privateHttpTokenRef = tokenRef;
+  }
+
+  static get isAuthenticated(): boolean {
+    return !!this.jwt;
+  }
+
+  static get jwt(): string | undefined {
+    return privateHttpTokenRef.token;
+  }
+
+  public request<I extends {}, R extends {}>(
+    method: 'get' | 'post' | 'put' | 'patch' | 'delete',
+    endpoint: string,
+    data?: I
+  ): Promise<R> {
+    const fetchOptions: RequestInit = { method };
+    fetchOptions.headers = {};
+
+    if (privateHttpTokenRef.token) {
+      fetchOptions.headers.Authorization = `JWT ${privateHttpTokenRef.token}`;
+    }
+
+    let url = this.uw.options.apiBaseUrl + endpoint;
+
+    if (method === 'get' && data) {
+      const querystring = querystringify(data);
+
+      if (querystring) {
+        url += `?${querystring}`;
+      }
+    } else if (data) {
+      fetchOptions.headers['Content-Type'] = 'application/json';
+      fetchOptions.body = JSON.stringify(data);
+    }
+
+    return fetch(url, fetchOptions).then((res) => res.json() as Promise<R>);
+  }
+
+  public get<I, R>(endpoint: string, query?: I): Promise<R> {
+    return this.request<I, R>('get', endpoint, query);
+  }
+
+  public post<I, R>(endpoint: string, data?: I): Promise<R> {
+    return this.request<I, R>('post', endpoint, data);
+  }
+
+  public put<I, R>(endpoint: string, data?: I): Promise<R> {
+    return this.request<I, R>('put', endpoint, data);
+  }
+
+  public patch<I, R>(endpoint: string, data?: I): Promise<R> {
+    return this.request<I, R>('patch', endpoint, data);
+  }
+
+  public delete<I, R>(endpoint: string, query?: I): Promise<R> {
+    return this.request<I, R>('delete', endpoint, query);
+  }
+}
+
+const querystringify = (obj: object = {}, keyPrefix?: string): string =>
+  Object.entries(obj)
+    .map(([key, value]) =>
+      typeof value !== 'object'
+        ? [keyPrefix ? `${keyPrefix}[${key}]` : key, value]
+            .map(encodeURIComponent)
+            .join('=')
+        : querystringify(value, key)
+    )
+    .join('&');

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -3,3 +3,4 @@ export { default as Booth } from './booth';
 
 // internal
 export { default as Socket } from './socket';
+export { default as Http } from './http';

--- a/src/modules/socket.spec.ts
+++ b/src/modules/socket.spec.ts
@@ -1,10 +1,10 @@
 import EventEmitter = require('events');
-import { PrivateSocketTokenRef, uWave } from '..';
+import { PrivateTokenRef, uWave } from '..';
 import SocketModule from './socket';
 
 test('should create an socket module instance', () => {
   const uw = new (class Test {})() as uWave;
-  const privateSocketTokenRef: PrivateSocketTokenRef = {};
+  const privateSocketTokenRef: PrivateTokenRef = {};
   const socket = new SocketModule(uw, privateSocketTokenRef);
 
   expect(socket).toBeInstanceOf(SocketModule);

--- a/src/modules/socket.ts
+++ b/src/modules/socket.ts
@@ -3,6 +3,7 @@ import { EventEmitter } from 'events';
 
 import { PrivateTokenRef, uWave } from '..';
 import { Commands, SocketEvents, SocketPayloadsMap } from '../types';
+import { Http } from '.';
 
 let privateSocketTokenRef: PrivateTokenRef = {};
 
@@ -83,7 +84,7 @@ export default class Socket {
 
     if (!this.socket || !this.isConnected) return;
 
-    if (!privateSocketTokenRef.token && this.uw.isAuthenticated) {
+    if (!privateSocketTokenRef.token && Http.isAuthenticated) {
       privateSocketTokenRef = { token: await this.uw.auth.getSocketToken() };
     }
 

--- a/src/modules/socket.ts
+++ b/src/modules/socket.ts
@@ -1,10 +1,10 @@
 import * as WebSocket from 'ws';
 import { EventEmitter } from 'events';
 
-import { PrivateSocketTokenRef, uWave } from '..';
+import { PrivateTokenRef, uWave } from '..';
 import { Commands, SocketEvents, SocketPayloadsMap } from '../types';
 
-const privateSocketTokenRef: PrivateSocketTokenRef = {};
+let privateSocketTokenRef: PrivateTokenRef = {};
 
 export default class Socket {
   private uw: uWave;
@@ -14,11 +14,11 @@ export default class Socket {
 
   static KEEP_ALIVE_MESSAGE = '-';
 
-  constructor(uw: uWave, tokenRef: PrivateSocketTokenRef) {
+  constructor(uw: uWave, tokenRef: PrivateTokenRef) {
     this.uw = uw;
     this.emitter = new EventEmitter();
 
-    privateSocketTokenRef.token = tokenRef.token;
+    privateSocketTokenRef = tokenRef;
   }
 
   public get isConnected(): boolean {
@@ -84,7 +84,7 @@ export default class Socket {
     if (!this.socket || !this.isConnected) return;
 
     if (!privateSocketTokenRef.token && this.uw.isAuthenticated) {
-      privateSocketTokenRef.token = await this.uw.auth.getSocketToken();
+      privateSocketTokenRef = { token: await this.uw.auth.getSocketToken() };
     }
 
     if (privateSocketTokenRef.token) {


### PR DESCRIPTION
### Code Refactoring

- **http**: removing isAuthenticated getter from index module since we have it in HttpModule (0452e33 (https://github.com/uriell/u-wave-nodejs-client/commit/0452e33bc497c5c0940d55b224a2dc51c5c74613))
- **http**: removing request, get, post, put, patch, delete methods and jwt getter from index (840e8fc (https://github.com/uriell/u-wave-nodejs-client/commit/840e8fce619387d9e26f0e88b0db46f8889c4206))

### Features

- **http**: a new http module for request handling, based from what we had on index (0ebb81a (https://github.com/uriell/u-wave-nodejs-client/commit/0ebb81a454ff865e470462bfd316892cb1588f48))

### Performance Improvements

- **auth**: removing authImmediately and credentials options from uWave constructor (4c4288d (https://github.com/uriell/u-wave-nodejs-client/commit/4c4288d041432289e07b47573943294dd6cd9418))

### BREAKING CHANGES

- **auth**: the authImmediately and credentials options were removed from the uWave
      constructor, please refer to the auth getter to mimic its implementation
- **http**: the request, get, post, put, patch and delete methods were removed from the index
      module, please refer to the http getter for their identic implementation
- **http**: the isAuthenticated getter was removed from the index module, in favor of
      HttpModule.isAuthenticated