### PR TITLE
[Feature] Chat methods

### DIFF
--- a/example/src/index.ts
+++ b/example/src/index.ts
@@ -42,7 +42,7 @@ uw.socket.on('connected', () => {
 uw.socket.on('authenticated', () => {
   console.info('authenticated');
 
-  uw.sendChat('hello world');
+  uw.chat.sendChat('hello world');
 });
 
 process.on('SIGINT', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,14 +88,6 @@ export class uWave {
     return !!this.jwt;
   }
 
-  public sendChat(message: string): void {
-    return this.socket.send({ command: 'sendChat', data: message });
-  }
-
-  public vote(direction: 1 | -1): void {
-    return this.socket.send({ command: 'vote', data: direction });
-  }
-
   // #region http
   public request<I extends {}, R extends {}>(
     method: 'get' | 'post' | 'put' | 'patch' | 'delete',

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import fetch, { RequestInit } from 'node-fetch';
 
-import { Auth, Booth, Socket } from './modules';
+import { Auth, Booth, Chat, Socket } from './modules';
 
 export interface IUWaveOptions {
   apiBaseUrl: string;
@@ -25,6 +25,7 @@ export class uWave {
     auth?: Auth;
     booth?: Booth;
     socket?: Socket;
+    chat?: Chat;
   } = {};
   // #endregion
 
@@ -73,6 +74,14 @@ export class uWave {
     }
 
     return this.modules.booth;
+  }
+
+  get chat(): Chat {
+    if (!this.modules.chat) {
+      this.modules.chat = new Chat(this);
+    }
+
+    return this.modules.chat;
   }
 
   get isAuthenticated(): boolean {

--- a/src/modules/chat.spec.ts
+++ b/src/modules/chat.spec.ts
@@ -1,0 +1,15 @@
+import { uWave } from '..';
+import ChatModule from './chat';
+
+test('should create an chat module instance', () => {
+  const uw = new (class Test {})() as uWave;
+  const chat = new ChatModule(uw);
+
+  expect(chat).toBeInstanceOf(ChatModule);
+  expect(chat['uw']).toEqual(uw);
+  expect(chat).toMatchInlineSnapshot(`
+Chat {
+  "uw": Test {},
+}
+`);
+});

--- a/src/modules/chat.ts
+++ b/src/modules/chat.ts
@@ -1,4 +1,5 @@
 import { uWave } from '..';
+import { uWaveAPI } from '../types';
 
 export default class Chat {
   private uw: uWave;
@@ -9,5 +10,38 @@ export default class Chat {
 
   public sendChat(message: string): void {
     return this.uw.socket.send({ command: 'sendChat', data: message });
+  }
+
+  public deleteAll(): Promise<null> {
+    return this.uw
+      .delete<{}, uWaveAPI.EmptyItemResponse>('/chat')
+      .then(() => null);
+  }
+
+  public deleteAllByUser(userId: string): Promise<null> {
+    return this.uw
+      .delete<{}, uWaveAPI.EmptyItemResponse>(`/chat/${userId}`)
+      .then(() => null);
+  }
+
+  public deleteMessage(messageId: string): Promise<null> {
+    return this.uw
+      .delete<{}, uWaveAPI.EmptyItemResponse>(`/chat/${messageId}`)
+      .then(() => null);
+  }
+
+  public muteUser(userId: string, duration: number): Promise<null> {
+    return this.uw
+      .post<uWaveAPI.MuteUserBody, uWaveAPI.EmptyItemResponse>(
+        `/users/${userId}/mute`,
+        { time: duration }
+      )
+      .then(() => null);
+  }
+
+  public unmuteUser(userId: string): Promise<null> {
+    return this.uw
+      .delete<{}, uWaveAPI.EmptyItemResponse>(`/users/${userId}/mute`)
+      .then(() => null);
   }
 }

--- a/src/modules/chat.ts
+++ b/src/modules/chat.ts
@@ -6,4 +6,8 @@ export default class Chat {
   constructor(uw: uWave) {
     this.uw = uw;
   }
+
+  public sendChat(message: string): void {
+    return this.uw.socket.send({ command: 'sendChat', data: message });
+  }
 }

--- a/src/modules/chat.ts
+++ b/src/modules/chat.ts
@@ -1,0 +1,9 @@
+import { uWave } from '..';
+
+export default class Chat {
+  private uw: uWave;
+
+  constructor(uw: uWave) {
+    this.uw = uw;
+  }
+}

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -1,5 +1,6 @@
 export { default as Auth } from './auth';
 export { default as Booth } from './booth';
+export { default as Chat } from './chat';
 
 // internal
 export { default as Socket } from './socket';

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -90,4 +90,6 @@ export declare namespace uWaveAPI {
     | { remove?: boolean };
 
   type ReplaceBoothBody = { userID: string };
+
+  type MuteUserBody = { time: number };
 }


### PR DESCRIPTION
This PR implements all the needed chat methods through a module exposed in the main class.

### Breaking Changes
- The method `#vote` is no longer available through the main class, please refer to `#booth.vote` for it's replacement;
- The method `#sendChat` is not longer available through the main class, please refer to `#chat.sendChat` for it's identic replacement;

### New APIs
- A new Chat module is exposed through the `#chat` getter;
- `#chat.sendChat(message: string): void`: Tries to send the specified message in the chat;
- `#chat.deleteAll(): Promise<null>`: Tries to delete all the chat messages that were sent;
- `#chat.deleteAllByUser(userId: string): Promise<null>`: Tries to delete all the chat messages sent by the specified user;
- `#chat.deleteMessage(messageId: string): Promise<null>`: Tries to delete the specified chat message;
- `#chat.muteUser(userId: string, duration: number): Promise<null>`: Tries to mute the specified user for the specified duration;
- `#chat.unmuteUser(userId: string): Promise<null>`: Tries to unmute the specified user;